### PR TITLE
chore: run go mod tidy and tell renovate to run it as well

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,6 +22,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v1.64
+          version: v2.8.0
           only-new-issues: true
           args: --timeout=20m

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,6 @@ github.com/google/pprof v0.0.0-20240727154555-813a5fbdbec8 h1:FKHo8hFI3A+7w0aUQu
 github.com/google/pprof v0.0.0-20240727154555-813a5fbdbec8/go.mod h1:K1liHPHnj73Fdn/EKuT8nrFqBihUSKXoLYU0BuatOYo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/gophercloud/gophercloud/v2 v2.0.0 h1:iH0x0Ji79a/ULzmq95fvOBAyie7+M+wUAEu+JrRMsCk=
-github.com/gophercloud/gophercloud/v2 v2.0.0/go.mod h1:ZKbcGNjxFTSaP5wlvtLDdsppllD/UGGvXBPqcjeqA8Y=
 github.com/gophercloud/gophercloud/v2 v2.10.0 h1:NRadC0aHNvy4iMoFXj5AFiPmut/Sj3hAPAo9B59VMGc=
 github.com/gophercloud/gophercloud/v2 v2.10.0/go.mod h1:Ki/ILhYZr/5EPebrPL9Ej+tUg4lqx71/YH2JWVeU+Qk=
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=
@@ -132,8 +130,6 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/rackerlabs/goclouddns v0.0.0-20240701182941-a63aed67a76c h1:qbOImSDKx6BU0HccJ76bE0Np6ZqncLjVUIlfM6EfT5w=
 github.com/rackerlabs/goclouddns v0.0.0-20240701182941-a63aed67a76c/go.mod h1:B8ss5N46nPrGGtfUUbPi2kvZjOKFDQaHadcqR6ueJ1w=
-github.com/rackerlabs/goraxauth v0.0.0-20240701164106-35b425b9a401 h1:e3WJlh31HRxZz8BDW1aXheI/Ed6ej8sTuXvvj15ADa0=
-github.com/rackerlabs/goraxauth v0.0.0-20240701164106-35b425b9a401/go.mod h1:9oICyo1cogXIwvRn+uk3bVwFQfSM6SZIa/OJEPhc7B8=
 github.com/rackerlabs/goraxauth v0.0.0-20260107155317-f536fcae8f4e h1:SJZwTUBPDygKHxnrBEnRG55XcbwpyqwsymUNDUsr+cQ=
 github.com/rackerlabs/goraxauth v0.0.0-20260107155317-f536fcae8f4e/go.mod h1:KFtfIfbD9umQ37l0vo8bZodo6mxA+yuRZ3V5jJ6818Y=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=

--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,9 @@
   "labels": ["dependencies"],
   "assignees": ["cardoe"],
   "reviewers": ["cardoe"],
+  "postUpdateOptions": [
+    "gomodTidy"
+  ],
   "packageRules": [
     {
       "matchManagers": ["gomod"],


### PR DESCRIPTION
Run `go mod tidy` and tell Renovate to run it as well. Upgrade golangci-lint since Renovate updated the action without the binary and broke things.